### PR TITLE
fix: prevent retries on expected errors

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-core-client
-version: 0.4.1
+version: 0.5.0
 crystal: ">= 1.0.0"
 license: MIT
 authors:

--- a/spec/error_spec.cr
+++ b/spec/error_spec.cr
@@ -1,0 +1,34 @@
+require "./spec_helper"
+
+describe PlaceOS::Core::ClientError do
+  it "should instantiate based on data in a HTTP response" do
+    error = PlaceOS::Core::ClientError.from_response(
+      "/testing",
+      HTTP::Client::Response.new(
+        status: :ok,
+        body: "some data",
+        headers: HTTP::Headers{
+          "Response-Code" => "208"
+        }
+      )
+    )
+
+    error.message.should eq "request to /testing failed with some data"
+    error.status_code.should eq 200
+    error.response_code.should eq 208
+    error.remote_backtrace.should eq nil
+
+    error = PlaceOS::Core::ClientError.from_response(
+      "/testing2",
+      HTTP::Client::Response.new(
+        status: :internal_server_error,
+        body: "error"
+      )
+    )
+
+    error.message.should eq "request to /testing2 failed with error"
+    error.status_code.should eq 500
+    error.response_code.should eq 500
+    error.remote_backtrace.should eq nil
+  end
+end

--- a/spec/error_spec.cr
+++ b/spec/error_spec.cr
@@ -8,7 +8,7 @@ describe PlaceOS::Core::ClientError do
         status: :ok,
         body: "some data",
         headers: HTTP::Headers{
-          "Response-Code" => "208"
+          "Response-Code" => "208",
         }
       )
     )

--- a/spec/placeos-core-client.cr
+++ b/spec/placeos-core-client.cr
@@ -1,9 +1,0 @@
-require "./spec_helper"
-
-describe Core::Client do
-  # TODO: Write tests
-
-  it "works" do
-    false.should eq(true)
-  end
-end

--- a/spec/placeos-core-client_spec.cr
+++ b/spec/placeos-core-client_spec.cr
@@ -1,0 +1,9 @@
+require "./spec_helper"
+
+describe PlaceOS::Core::Client do
+  it "specs" do
+    pending!("TODO: Write tests")
+
+    false.should eq(true)
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,2 @@
 require "spec"
-require "../src/core-client"
+require "../src/placeos-core-client"

--- a/src/error.cr
+++ b/src/error.cr
@@ -10,7 +10,7 @@ module PlaceOS::Core
   class ClientError < Error
     getter status_code : Int32
     getter response_code : Int32
-    getter remote_backtrace : Array(String)?
+    getter remote_backtrace : Array(String)? = nil
 
     def initialize(@status_code : Int32, message = "", @response_code : Int32 = 500)
       super(message)

--- a/src/error.cr
+++ b/src/error.cr
@@ -8,45 +8,42 @@ module PlaceOS::Core
   end
 
   class ClientError < Error
-    getter status_code
-    getter response_code
-    getter remote_backtrace
+    getter status_code : Int32
+    getter response_code : Int32
+    getter remote_backtrace : Array(String)?
 
-    enum ErrorCode
-      # The request was sent and error occured in core / the module
-      RequestFailed = 0
-      # Some other transient failure like database unavailable
-      UnexpectedFailure = 1
-
-      def to_s
-        super.underscore
-      end
-    end
-
-    def initialize(@status_code : Int32, message = "", @module_code : Int32 = 500)
+    def initialize(@status_code : Int32, message = "", @response_code : Int32 = 500)
       super(message)
     end
 
-    def initialize(path : String, @status_code : Int32, message : String, @module_code : Int32 = 500)
+    def initialize(path : String, @status_code : Int32, message : String, @response_code : Int32 = 500)
       super("request to #{path} failed with #{message}")
     end
 
-    def initialize(path : String, @status_code : Int32, @module_code : Int32 = 500)
+    def initialize(path : String, @status_code : Int32, @response_code : Int32 = 500)
       super("request to #{path} failed")
     end
 
     def initialize(
-      error_code : ErrorCode,
       @status_code : Int32,
       message : String = "",
       @remote_backtrace : Array(String)? = nil,
-      @module_code : Int32 = 500
+      @response_code : Int32 = 500
     )
       super(message)
     end
 
     def self.from_response(path : String, response : HTTP::Client::Response)
-      new(path, response.status_code, response.body)
+      new(path, response.status_code, response.body, response.headers["Response-Code"]?.try(&.to_i) || (response.success? ? 200 : 500))
     end
+  end
+
+  class DriverRaisedError < ClientError
+  end
+
+  class UnexpectedFailureError < ClientError
+  end
+
+  class APIResponseError < ClientError
   end
 end


### PR DESCRIPTION
break up errors for improved retry handling and error propagation
removed unused `ErrorCode` enum
